### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Email/Simple.pm6
+++ b/lib/Email/Simple.pm6
@@ -1,4 +1,4 @@
-class Email::Simple;
+unit class Email::Simple;
 
 use Email::Simple::Header;
 use DateTime::Format::RFC2822;

--- a/lib/Email/Simple/Header.pm6
+++ b/lib/Email/Simple/Header.pm6
@@ -1,4 +1,4 @@
-class Email::Simple::Header;
+unit class Email::Simple::Header;
 
 has $!crlf;
 has @!headers;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.