### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-BEGIN { @*INC.push: './lib'; }
+use lib 'lib';
 
 use Email::Simple;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.