### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"    : "6.*",
     "name"	  : "Email::Simple",
+    "license" : "CC0-1.0",
     "version"	  : "2.0.0",
     "author"      : "github:retupmoca",
     "description" : "Simple email parsing module",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license